### PR TITLE
fix(lab0201): apply style corrections, fix typos, and update callout blocks

### DIFF
--- a/Instructions/Labs/0201-Configuring and managing Azure AD join.md
+++ b/Instructions/Labs/0201-Configuring and managing Azure AD join.md
@@ -144,12 +144,19 @@ You need to configure Entra ID device settings to ensure that all users are allo
 
 3. On the **Let's keep your account secure** page, select **Next**.
 
-4. On the **Install Microsoft Authenticator** page, select **Set up a different way to sign in**. **Note** Ensure you select the correct link.
+4. On the **Install Microsoft Authenticator** page, select **Set up a different way to sign in**.
+
+   > [!NOTE]
+   > Ensure you select the correct link.
 
 5. On the **Add a sign-in method** dialog box, select **Phone**.
 
 6. On the **Add your phone number** page, select your **Country code** and in the **Phone number** field, enter your mobile phone number which is able to receive text messages, then select **Next**.
 
+   > [!NOTE]
+   > This lab environment does not support SMS delivery to non-US phone numbers.
+   > If you do not have a US phone number, select **Set up a different way to sign in**
+   > and choose **Microsoft Authenticator** to complete MFA registration.
 7. When you receive the verification code, enter the code on the **Verify your phone number** page and then select **Next**.
 
 8. On the **Phone number added** page, select **Done**.

--- a/Instructions/Labs/0201-Configuring and managing Azure AD join.md
+++ b/Instructions/Labs/0201-Configuring and managing Azure AD join.md
@@ -303,7 +303,7 @@ Some Contoso Windows devices are currently joined to the local Active Directory 
 
 8. Switch to **SEA-SVR1** and switch to the **Microsoft Entra admin center**.
 
-9. Select **Devices** > **All devices**. 
+9. Select **Devices** > **All devices**.
 
 10. Verify that **SEA-CL2** has **Microsoft Entra hybrid joined** as the value for the **Join Type** column. If **SEA-CL2** is not listed, select **Refresh**.
 

--- a/Instructions/Labs/0201-Configuring and managing Azure AD join.md
+++ b/Instructions/Labs/0201-Configuring and managing Azure AD join.md
@@ -82,7 +82,7 @@ You need to configure Entra ID device settings to ensure that all users are allo
 
 3. In the **Settings** window, select **Accounts**.
 
-4. On the Accounts page, select **Access work or school**.
+4. On the **Accounts** page, select **Access work or school**.
 
 5. In the **Access work or school** page, select **Connect**.
 
@@ -118,7 +118,7 @@ You need to configure Entra ID device settings to ensure that all users are allo
 
 5. Right-click **Start** and then select **Computer Management**.
 
-6. In Computer Management, expand **Local Users and Groups**, and then select **Groups**.
+6. In **Computer Management**, expand **Local Users and Groups**, and then select **Groups**.
 
 7. Double-select the **Administrators** group.
 
@@ -128,7 +128,7 @@ You need to configure Entra ID device settings to ensure that all users are allo
 
 9. Switch to **SEA-SVR1**.
 
-10. In Microsoft Edge, in the Microsoft Entra admin center, select **Devices**, and then select **All devices**. 
+10. In Microsoft Edge, in the **Microsoft Entra admin center**, select **Devices**, and then select **All devices**. 
 
     > In the Devices pane, notice that SEA-WS1 is listed. 
 

--- a/Instructions/Labs/0201-Configuring and managing Azure AD join.md
+++ b/Instructions/Labs/0201-Configuring and managing Azure AD join.md
@@ -291,8 +291,9 @@ Some Contoso Windows devices are currently joined to the local Active Directory 
 
 6. In the output under **Device State**, verify that **AzureAdJoined : YES** and **DomainJoined : YES** are displayed.
 
-   > **Note**: If the device is not yet joined to Entra ID, switch back to **SEA-SRV1** and run the command below. Once completed, switch back to SEA-CL2 and restart the computer once more.
-   
+   > [!NOTE]
+   > If the device is not yet joined to Entra ID, switch back to **SEA-SVR1** and run the command below. Once completed, switch back to **SEA-CL2** and restart the computer once more.
+
    ```powershell
    Start-ADSyncSyncCycle -PolicyType Delta
    ```

--- a/Instructions/Labs/0201-Configuring and managing Azure AD join.md
+++ b/Instructions/Labs/0201-Configuring and managing Azure AD join.md
@@ -21,7 +21,8 @@ The following lab(s) must be completed before this lab:
 
 - 0102-Synchronizing Identities by using Microsoft Entra Connect
 
-  > Note: You will also need a mobile phone that can receive text messages used to secure Windows Hello sign in authentication to Entra ID.
+> [!NOTE]
+> You will also need a mobile phone that can receive text messages used to secure Windows Hello sign in authentication to Entra ID.
 
 ## Exercise 1: Configuring Entra Join
 
@@ -33,7 +34,7 @@ You need to configure Entra ID device settings to ensure that all users are allo
 
 1. On **SEA-SVR1**, if necessary, sign in as **Contoso\\Administrator** with the password of **Pa55w.rd** and close Server Manager.
 
-2. On the taskbar select **Microsoft Edge**, in the address bar type **https://entra.microsoft.com**, and then press **Enter**.
+2. On the taskbar, select **Microsoft Edge**, in the address bar enter `https://entra.microsoft.com`, and then press **Enter**.
 
 3. Sign in as user `Admin@yourtenant.onmicrosoft.com`, and use the tenant Admin password. If the **Stay signed in?** prompt appears, select **No**. 
 
@@ -45,7 +46,7 @@ You need to configure Entra ID device settings to ensure that all users are allo
 
 5. On the **Devices | All devices** page, select **Device settings**.
 
-6. On the **Devices|Device settings** page, in the details pane, under **Users may join devices to Microsoft Entra**, verify that **All** is selected. 
+6. On the **Devices | Device settings** page, in the details pane, under **Users may join devices to Microsoft Entra**, verify that **All** is selected. 
 
    > This indicates that all Entra users are permitted to join Windows 10 or newer devices to Microsoft Entra. Note that this setting does not apply to Entra hybrid  joined devices, or devices joined by using Windows Autopilot self-deployment mode.
 
@@ -55,7 +56,7 @@ You need to configure Entra ID device settings to ensure that all users are allo
 
 9. Under **Local administrator settings**, select **Manage Additional local administrators on all Entra joined devices**. The Device Administrators page opens.
 
-10. In the Device Administrators page, select **+ Add assignments**.
+10. In the **Device Administrators page**, select **+ Add assignments**.
 
 11. In the Search box, enter **Allan Deyoung**, select the **Allan Deyoung** user object, and then select **Add**. 
 
@@ -65,11 +66,11 @@ You need to configure Entra ID device settings to ensure that all users are allo
 
 13. On the Device settings page, select **Save**.
 
-14. In the Entra admin center, in the navigation pane, select **Authentication methods**.
+14. In the **Entra admin center**, in the navigation pane, select **Authentication methods**.
 
 15. In the **Authentication methods** page, select **SMS**.
 
-16. In the **SMS settings** page, select **Enable** (to make SMS available as an authenticatiom method).
+16. In the **SMS settings** page, select **Enable** (to make SMS available as an authentication method).
 
 17. At the bottom of the page, select **Save**.
 
@@ -87,7 +88,7 @@ You need to configure Entra ID device settings to ensure that all users are allo
 
 6. In the **Microsoft account** window, select **Join this device to Microsoft Entra ID**.
 
-7. On the **Sign in** page, type **JoniS@yourtenant.onmicrosoft.com** and then select **Next**.
+7. On the **Sign in** page, enter `JoniS@yourtenant.onmicrosoft.com` and then select **Next**.
 
 8. On the **Enter password** page, enter the user password (from the Resources tab) and then select **Sign in**.
 
@@ -119,7 +120,7 @@ You need to configure Entra ID device settings to ensure that all users are allo
 
 6. In Computer Management, expand **Local Users and Groups**, and then select **Groups**.
 
-7. Double-click the **Administrators** group.
+7. Double-select the **Administrators** group.
 
    > Notice that Joni Sherman has been added as a local Administrator on SEA-WS1. Also notice two security principals represented by their security identifiers (SID). These two SIDs represent the Entra ID global administrator role, and the Entra joined device administrator role. 
 
@@ -137,7 +138,7 @@ You need to configure Entra ID device settings to ensure that all users are allo
 
 ### Task 4: Sign in to Windows as an Entra User
 
-1. Switch to **SEA-WS1** and then sign in as **`JoniS@yourtenant.onmicrosoft.com`** with the user password you used in the previous task. 
+1. Switch to **SEA-WS1** and then sign in as `JoniS@yourtenant.onmicrosoft.com` with the user password you used in the previous task. 
 
 2. At the **Use Windows Hello with your account** page, select **OK**.
 

--- a/Instructions/Labs/0201-Configuring and managing Azure AD join.md
+++ b/Instructions/Labs/0201-Configuring and managing Azure AD join.md
@@ -221,7 +221,7 @@ Some Contoso Windows devices are currently joined to the local Active Directory 
 
 5. On the **Connect to Microsoft Entra ID** page, select **Next**.
 
-6. On the **Sign in to your account** window, select the tenant admin account, and then enter the tenant password and select **Sign in**.
+6. On the **Sign in to your account** window, select the tenant admin account, enter the tenant password, and then select **Sign in**.
 
 7. On the **Device options** page, select **Configure Hybrid Microsoft Entra ID join**, and then select **Next**.
 
@@ -255,7 +255,7 @@ Some Contoso Windows devices are currently joined to the local Active Directory 
 
 4. On the **Connect to Microsoft Entra ID** page, select **Next**.
 
-5. One the **Sign in to your account** window, select the tenant admin account, and then enter the tenant password and select **Sign in**.
+5. On the **Sign in to your account** window, select the tenant admin account, enter the tenant password, and then select **Sign in**.
 
 6. On the **Connect your directories** page, select **Next**.
 
@@ -299,11 +299,11 @@ Some Contoso Windows devices are currently joined to the local Active Directory 
 
 7. Close all windows on SEA-CL2 and sign out.
 
-8. Switch to **SEA-SVR1** and switch to the Microsoft Entra admin center.
+8. Switch to **SEA-SVR1** and switch to the **Microsoft Entra admin center**.
 
 9. Select **Devices** > **All devices**. 
 
-10. Verify that **SEA-CL2** has **Microsoft Entra hybrid joined** as value for the row **Join Type**. If necessary, select the **Refresh** button if SEA-CL2 is not listed.
+10. Verify that **SEA-CL2** has **Microsoft Entra hybrid joined** as the value for the **Join Type** column. If **SEA-CL2** is not listed, select **Refresh**.
 
 11. Close all windows on **SEA-SVR1**.
 

--- a/Instructions/Labs/0201-Configuring and managing Azure AD join.md
+++ b/Instructions/Labs/0201-Configuring and managing Azure AD join.md
@@ -277,10 +277,11 @@ Some Contoso Windows devices are currently joined to the local Active Directory 
 
 2. Right-click **Start**, select **Shut down or sign out**, and then select **Restart**.
 
-    _Note: The reboot will trigger the Entra hybrid join on SEA-CL2._
-   
+   > [!NOTE]
+   > The reboot will trigger the Entra hybrid join on **SEA-CL2**.
+
 3. After **SEA-CL2** has restarted, sign in as **Contoso\\Administrator** with the password of **Pa55w.rd**.
-    
+
 4. On the taskbar, right-click **Start** and select **Windows Terminal (Admin)**.
 
 5. In the **Windows PowerShell** window, type the following command, and then press **Enter**:
@@ -298,7 +299,7 @@ Some Contoso Windows devices are currently joined to the local Active Directory 
    Start-ADSyncSyncCycle -PolicyType Delta
    ```
 
-7. Close all windows on SEA-CL2 and sign out.
+7. Close all windows on **SEA-CL2** and sign out.
 
 8. Switch to **SEA-SVR1** and switch to the **Microsoft Entra admin center**.
 


### PR DESCRIPTION
## Summary

Applies Microsoft Learn style guidelines and fixes typos across Lab 0201 (Configuring and managing Entra Join). Changes span both exercises and include callout block formatting, bold consistency for UI elements, spelling corrections, and deprecated formatting cleanup.

## Changes

### Exercise 1
- Convert indented prerequisite note to column-0 `[!NOTE]` callout block
- Replace `type` with `enter` and apply backtick formatting to URLs and typed values
- Add missing bold to UI element names (Accounts page, Device Administrators page, Entra admin center, Computer Management, Microsoft Entra admin center)
- Fix `authenticatiom` typo to `authentication`
- Replace `Double-click` with `Double-select`
- Remove bold from typed value `JoniS@yourtenant.onmicrosoft.com`
- Convert inline `**Note**` to `[!NOTE]` callout block in Task 4, step 4
- Add `[!NOTE]` callout for non-US phone number SMS limitation
- Add missing `Devices|Device settings` spacing to `Devices | Device settings`

### Exercise 2
- Fix serial comma ordering in sign-in steps (Tasks 2 and 3)
- Fix `One the` typo to `On the` in Task 3, step 5
- Convert italic `_Note:_` and legacy `> **Note**:` to `[!NOTE]` callout blocks (Task 4)
- Fix server name typo `SEA-SRV1` to `SEA-SVR1` (Task 4, step 6)
- Add missing bold to `SEA-CL2`, `Microsoft Entra admin center` references
- Reword verification step 10 for clarity
- Remove trailing whitespace

## Files changed

- `Instructions/Labs/0201-Configuring and managing Azure AD join.md` - 34 insertions, 24 deletions across Exercises 1 and 2