### PR TITLE
style(lab0203): apply Microsoft Learn style and update deprecated terminology

### DIFF
--- a/Instructions/Labs/0203-Manage Device Enrollment into Intune.md
+++ b/Instructions/Labs/0203-Manage Device Enrollment into Intune.md
@@ -22,19 +22,20 @@ The following lab(s) must be completed before this lab:
 
 - 0101-Managing Identities in Entra ID
 
-- 0102-Synchronizing identities by using Entra Connect
+- 0102-Synchronizing identities by using Microsoft Entra Connect
 
-  > Note: You will also need a mobile phone that can receive text messages used to secure Windows Hello sign in authentication to Entra ID.
+> [!NOTE]
+> You will also need a mobile phone that can receive text messages used to secure Windows Hello sign in authentication to Microsoft Entra ID.
 
 ### Scenario
 
-You need to prepare for device management using Microsoft Intune. First of all, you need to ensure that users are assigned appropriate licenses for device management. As a verification test, you will assign Aaron Nicholls the required licenses. You also need to ensure that any Windows device that is joined or registered to Entra ID will automatically be enrolled into Intune. You have also been asked to ensure that members of the Sales group are restricted from enrolling personal Android devices into Intune and that the Enrollment Device Limit is increased to 10 devices. Finally, you need to configure Allan Deyoung as a Device enrollment manager to allow him to enroll 1000 devices.
+You need to prepare for device management using Microsoft Intune. You need to ensure that users are assigned appropriate licenses for device management. As a verification test, you will assign Aaron Nicholls the required licenses. You also need to ensure that any Windows device that is joined or registered to Microsoft Entra ID will automatically be enrolled into Intune. You have also been asked to ensure that members of the Sales group are restricted from enrolling personal Android devices into Intune and that the Enrollment Device Limit is increased to 10 devices. Finally, you need to configure Allan Deyoung as a Device enrollment manager to allow him to enroll 1000 devices.
 
 ### Task 1: Review and assign licenses for device management
 
 1. On **SEA-SVR1**, if necessary, sign in as **Contoso\\Administrator** with the password of **Pa55w.rd** and close **Server Manager**.
 
-2. On the taskbar select **Microsoft Edge**, in the address bar type **https://admin.microsoft.com**, and then press **Enter**.
+2. On the taskbar select **Microsoft Edge**, in the address bar type `https://admin.cloud.microsoft`, and then press **Enter**.
 
 3. Sign in as user `Admin@yourtenant.onmicrosoft.com`, and use the tenant Admin password. If the **Stay signed in?** prompt appears, select **No**. 
 
@@ -46,7 +47,7 @@ You need to prepare for device management using Microsoft Intune. First of all, 
 
 6. Select the **Licenses and apps** tab.
 
-7. If the **Select location** field is not populated, select the a location from the drop-down list.
+7. If the **Select location** field is not populated, select a location from the drop-down list.
 
 8. Select the check boxes next to **Enterprise Mobility + Security E5** and **Office 365 E5 (no Teams)**.
 
@@ -57,7 +58,7 @@ You need to prepare for device management using Microsoft Intune. First of all, 
 
 ### Task 2: Enable Windows Automatic Enrollment into Microsoft Intune
 
-1. In **SEA-SVR1**, open a new tab in **Microsoft Edge**, and then in the address bar type **https://intune.microsoft.com**, and then press **Enter**. 
+1. In **SEA-SVR1**, open a new tab in **Microsoft Edge**, and then in the address bar type `https://intune.microsoft.com`, and then press **Enter**.
 
    > The Microsoft Intune admin center opens.
 
@@ -71,60 +72,63 @@ You need to prepare for device management using Microsoft Intune. First of all, 
 
 6. On the **MDM user scope** row, select **All** and then select **Save**.
 
-   _**Note**: By performing this step, you enabled automatic enrollment into Intune for any User that performs an Entra join or Entra registration from a Windows device._
+   > [!NOTE]
+   > By performing this step, you enable automatic enrollment into Intune for any user that performs a Microsoft Entra join or Microsoft Entra registration from a Windows device.
 
 ### Task 3: Configure Enrollment Restrictions
 
 1. In the Microsoft Intune admin center, select **Devices**.
 
-2. On the Devices pane, under the **Device onboarding** section, select **Enrollment**.
+2. On the **Devices** pane, under the **Device onboarding** section, select **Enrollment**.
 
-3. On the **Devices | Enrollment** page, in the **Enrollment options** section, note that you can create enrollment device limit and platform restrictions. 
+3. On the **Devices | Enrollment** page, in the **Enrollment options** section, note that you can create enrollment device limit and platform restrictions.
 
-4. Select **Device platform restriction**. 
+4. Select **Device platform restriction**.
 
    > Notice that there is a Default device type restriction that is assigned to **All Users**. This default restriction allows all device types.
 
-5. In the details pane, select the **Android restrictions** tab, and then select **+ Create restriction**.
+5. On the **Enrollment restrictions** page, select the **Android restrictions** tab, and then select **+ Create restriction**.
 
-6. On the Create restriction page, in the Name box enter **Android Personal Device Restriction**. Select **Next**.
+6. On the Create restriction page, in the **Name** box enter **Android Personal Device Restriction**. Select **Next**.
 
-7. On the Platform settings page, under **Personally owned**, select **Block** for the following device types:
+7. On the **Platform settings** page, under **Personally owned**, select **Block** for the following device types:
 
    - Android Enterprise (work profile)
    - Android device administrator
 
-8. On the Platform settings page, select **Next**.
+8. On the **Platform settings** page, select **Next**.
 
-9. On the Scope tags page, select **Next**.
+9. On the **Scope tags** page, select **Next**.
 
-10. On the Assignments page, under Included groups, select **Add groups**.
+10. On the **Assignments** page, under **Included groups**, select **Add groups**.
 
-11. Search for and Select **Sales** and then click **Select** and then click **Next**.
+11. Search for and select **Sales**, select **Select**, and then select **Next**.
 
 12. On the **Review + create** page, select **Create**.
 
     > Notice the Android Personal Device Restriction assigned with a priority of 1.
 
-13. In the navigation breadcrumbs, select **Devices | Enrollment**.
+13. In the Microsoft Intune admin center, select **Devices**.
 
-14. In the **Enrollment options** section, select **Device limit restriction**. 
+14. On the **Devices** pane, under **Device onboarding**, select **Enrollment**.
+
+15. In the **Enrollment options** section, select **Device limit restriction**.
 
     > Notice that there is a Default device limit restriction that is assigned to **All Users**. This default restriction sets a device enrollment limit to 5 devices per user.
 
-15. In the details pane, select **+ Create restriction**.
+16. In the details pane, select **+ Create restriction**.
 
-16. On the Create restriction page, in the Name box enter **Sales Device Enrollment Limit**. Select **Next**.
+17. On the **Create restriction** page, in the **Name** box enter **Sales Device Enrollment Limit**. Select **Next**.
 
-17. On the Device limit page, select **10** and then select **Next**.
+18. On the **Device limit** page, select **10** and then select **Next**.
 
-18. On the Scope tags page, select **Next**.
+19. On the **Scope tags** page, select **Next**.
 
-19. On the Assignments page, under Included groups, select **Add groups**.
+20. On the **Assignments** page, under **Included groups**, select **Add groups**.
 
-20. Search for and Select **Sales** and then click **Select** and then click **Next**.
+21. Search for and select **Sales**, select **Select**, and then select **Next**.
 
-21. On the **Review + create** page, select **Create**.
+22. On the **Review + create** page, select **Create**.
 
     > Notice the Sales Device Enrollment Limit, configured with a Device limit of 10 and assigned with a priority of 1.
 
@@ -134,13 +138,13 @@ You need to prepare for device management using Microsoft Intune. First of all, 
 
 2. On the Devices pane, select **Enrollment**.
 
-3. On the **Enroll devices** pane, select **Device enrollment managers**. 
+3. On the **Devices | Enrollment** page, select the **Device enrollment managers** tab.
 
    > Notice that, by default, there are no Device enrollment managers configured.
 
 4. On the **Devices|Device enrollment managers** page, select **+ Add**.
 
-5. In the **Add user** page, under User name, enter `AllanD@yourtenant.onmicrosoft.com` and then select **Add**.
+5. In the **Add user** pane, under **User name**, enter `AllanD@yourtenant.onmicrosoft.com` and then select **Add**.
 
    > Allan is now allowed to enroll up to 1000 devices.
 
@@ -148,7 +152,7 @@ You need to prepare for device management using Microsoft Intune. First of all, 
 
 7. Close Microsoft Edge.
 
-**Results**: After completing this exercise, you will have successfully reviewed and assigned licenses, configured Windows automatic enrollment, enabled and assigned enrollment restrictions, and configured a Device enrollment manager.
+**Results**: After completing this exercise, you have successfully reviewed and assigned licenses, configured Windows automatic enrollment, enabled and assigned enrollment restrictions, and configured a Device enrollment manager.
 
 
 **END OF LAB**


### PR DESCRIPTION
## Summary

Updates Lab 0203 (Manage Device Enrollment into Intune) to comply with Microsoft Learn style guidelines and replace deprecated Azure AD terminology with current Microsoft Entra naming.

## Changes

- Replaced `Entra Connect` and `Entra ID` with `Microsoft Entra Connect` and `Microsoft Entra ID` throughout
- Converted legacy `> Note:` and `_**Note**:` callout formats to standard `> [!NOTE]` blocks at column 0
- Changed `click` to `select` for UI interactions
- Changed URLs from bold to backtick formatting (values typed, not UI elements)
- Added bold formatting to UI element names that were plain text (pane names, field labels, page names)
- Fixed typo: `select the a location` → `select a location`
- Removed filler phrase `First of all`
- Fixed future tense: `you will have successfully` → `you have successfully`
- Updated admin center URL from `https://admin.microsoft.com` to `https://admin.cloud.microsoft`
- Updated navigation steps in Tasks 3–4 to reflect current Intune admin center UI
- Removed trailing whitespace

## Files changed

- `Instructions/Labs/0203-Manage Device Enrollment into Intune.md` — Style fixes, deprecated terminology updates, callout block format corrections, navigation step updates, and typo fix