### PR TITLE
fix(lab0303): update instructions for UI drift and style

### DIFF
--- a/Instructions/Labs/0303-Using a Configuration Profile to configure iOS and iPadOS Wifi settings.md
+++ b/Instructions/Labs/0303-Using a Configuration Profile to configure iOS and iPadOS Wifi settings.md
@@ -34,7 +34,7 @@ You have been asked to create a Configuration policy to be used to automatically
 
 2. On **SEA-SVR1**, on the taskbar, select **Microsoft Edge**.
 
-3. In Microsoft Edge, type **https://intune.microsoft.com** in the address bar, and then press **Enter**. 
+3. In **Microsoft Edge**, type **https://intune.microsoft.com** in the address bar, and then press **Enter**.
 
 4. Sign in as **`admin@yourtenant.onmicrosoft.com`** with the tenant Admin password.
 
@@ -42,16 +42,18 @@ You have been asked to create a Configuration policy to be used to automatically
 
 6. On the **Groups | All groups** blade, select **New group**.
 
-7. On the **New Group** blade, enter the following information:
+7. On the **New Group** blade, enter and select the following information:
 
     - Group type: **Security**
     - Group name: **iOS_iPadOS Devices**
     - Group description: **All iOS and iPadOS devices**
     - Membership type: **Assigned**
 
-8. On the **New Group** blade, select **Create**. 
+8. On the **New Group** blade, select **Create**.
 
-9. On the **Groups | All groups** blade, verify that the **iOS_iPadOS Devices** group is displayed. You may need to select the Refresh button for the new group to become visible.
+9. Select **All groups**.
+
+10. On the **Groups | All groups** blade, verify that the **iOS_iPadOS Devices** group is displayed. You may need to select the **Refresh** button for the new group to become visible.
 
 ### Task 2: Create a Configuration policy based on scenario requirements
 

--- a/Instructions/Labs/0303-Using a Configuration Profile to configure iOS and iPadOS Wifi settings.md
+++ b/Instructions/Labs/0303-Using a Configuration Profile to configure iOS and iPadOS Wifi settings.md
@@ -61,7 +61,7 @@ You have been asked to create a Configuration policy to be used to automatically
 
 2. On the **Devices** page, under **Manage devices** section, select **Configuration**.
 
-3. On the **Devices | Configuration** blade, in the details pane, select **+ Create**, and then select **+ New Policy**.
+3. On the **Devices | Configuration** blade, in the **Policies** tab, select **+ Create**, and then select **+ New Policy**.
 
 4. In the **Create a profile** blade, select the following options, and then select **Create**:
 

--- a/Instructions/Labs/0303-Using a Configuration Profile to configure iOS and iPadOS Wifi settings.md
+++ b/Instructions/Labs/0303-Using a Configuration Profile to configure iOS and iPadOS Wifi settings.md
@@ -1,7 +1,7 @@
 ---
 lab:
   title: 'Practice Lab 0303: Using a Configuration policy to configure iOS and iPadOS Wi-Fi settings'
-  description: In this lab, you use Microsoft Intune to create and apply a Configuration policy to run configure Wi-Fi settings for iOS and iPadOS devices.
+  description: In this lab, you use Microsoft Intune to create and apply a Configuration policy to configure Wi-Fi settings for iOS and iPadOS devices.
   duration: 30 minutes
   level: 200
   islab: true
@@ -13,7 +13,7 @@ lab:
 
 ## Summary
 
-In this lab, you use Microsoft Intune to create and apply a Configuration policy to run configure Wi-Fi settings for iOS and iPadOS devices.
+In this lab, you use Microsoft Intune to create and apply a Configuration policy to configure Wi-Fi settings for iOS and iPadOS devices.
 
 ## Exercise 1: Creating a Configuration policy
 
@@ -59,7 +59,7 @@ You have been asked to create a Configuration policy to be used to automatically
 
 1. In the Microsoft Intune admin center, select **Devices** from the navigation bar.
 
-2. On the **Devices** page, under **Manage devices** section, select **Configuration**.
+2. On the **Devices** page, under the **Manage devices** section, select **Configuration**.
 
 3. On the **Devices | Configuration** blade, in the **Policies** tab, select **+ Create**, and then select **+ New Policy**.
 
@@ -75,11 +75,11 @@ You have been asked to create a Configuration policy to be used to automatically
     - Name: **iOS/iPadOS Wi-Fi Policy**
     - Description: **Wi-Fi settings for iOS/iPadOS Devices.**
 
-7. On the **Configuration settings** blade, next to **Wi-Fi type**, select **Basic**. 
+7. On the **Configuration settings** blade, next to **Wi-Fi type**, select **Basic**.
 
    > Additional options display based upon the type selected.
 
-8. On the **Configuration settings** blade, select the following options, and then select **Next**:
+8. On the **Configuration settings** blade, enter and select the following options, and then select **Next**:
 
     - Network name: **Contoso Wi-Fi**
     - SSID: **MainOffice**
@@ -89,14 +89,14 @@ You have been asked to create a Configuration policy to be used to automatically
 
 9. On the **Assignments** blade, under **Included groups**, select **Add groups**.
 
-10. In the **Select groups to include** window, select **iOS_iPadOS Devices**, and then click **Select**.
+10. In the **Select groups to include** window, select **iOS_iPadOS Devices**, and then select **Select**.
 
 11. Select **Next** until you reach the **Review + create** blade. Select **Create**.
 
-12. Refresh the **Devices | Configuration** blade, and verify that the **iOS/iPadOS Wi-Fi Policy** is listed. 
+12. Refresh the **Devices | Configuration** blade, and verify that the **iOS/iPadOS Wi-Fi Policy** is listed.
 
-13. Close the Edge browser.
+13. Close **Microsoft Edge**.
 
-**Results**: After completing this exercise, you will have successfully created and assigned a Configuration policy to configure Wi-Fi settings for iOS and iPadOS devices.
+**Results**: After completing this exercise, you have successfully created and assigned a Configuration policy to configure Wi-Fi settings for iOS and iPadOS devices.
 
 **END OF LAB**

--- a/Instructions/Labs/0303-Using a Configuration Profile to configure iOS and iPadOS Wifi settings.md
+++ b/Instructions/Labs/0303-Using a Configuration Profile to configure iOS and iPadOS Wifi settings.md
@@ -40,20 +40,20 @@ You have been asked to create a Configuration policy to be used to automatically
 
 5. In the Microsoft Intune admin center, in the navigation pane, select **Groups**.
 
-6. On the **Groups | All groups** blade, select **New group**.
+6. On the **Groups | All groups** page, select **New group**.
 
-7. On the **New Group** blade, enter and select the following information:
+7. On the **New Group** page, enter and select the following information:
 
     - Group type: **Security**
     - Group name: **iOS_iPadOS Devices**
     - Group description: **All iOS and iPadOS devices**
     - Membership type: **Assigned**
 
-8. On the **New Group** blade, select **Create**.
+8. On the **New Group** page, select **Create**.
 
 9. Select **All groups**.
 
-10. On the **Groups | All groups** blade, verify that the **iOS_iPadOS Devices** group is displayed. You may need to select the **Refresh** button for the new group to become visible.
+10. On the **Groups | All groups** page, verify that the **iOS_iPadOS Devices** group is displayed. You may need to select the **Refresh** button for the new group to become visible.
 
 ### Task 2: Create a Configuration policy based on scenario requirements
 
@@ -61,25 +61,25 @@ You have been asked to create a Configuration policy to be used to automatically
 
 2. On the **Devices** page, under the **Manage devices** section, select **Configuration**.
 
-3. On the **Devices | Configuration** blade, in the **Policies** tab, select **+ Create**, and then select **+ New Policy**.
+3. On the **Devices | Configuration** page, in the **Policies** tab, select **+ Create**, and then select **+ New Policy**.
 
-4. In the **Create a profile** blade, select the following options, and then select **Create**:
+4. In the **Create a profile** page, select the following options, and then select **Create**:
 
     - Platform: **iOS/iPadOS**
     - Profile type: **Templates**
 
 5. Select **Wi-Fi** from the list of templates, and then select **Create**.
 
-6. In the **Basics** blade, enter the following information, and then select **Next**:
+6. In the **Basics** page, enter the following information, and then select **Next**:
 
     - Name: **iOS/iPadOS Wi-Fi Policy**
     - Description: **Wi-Fi settings for iOS/iPadOS Devices.**
 
-7. On the **Configuration settings** blade, next to **Wi-Fi type**, select **Basic**.
+7. On the **Configuration settings** page, next to **Wi-Fi type**, select **Basic**.
 
    > Additional options display based upon the type selected.
 
-8. On the **Configuration settings** blade, enter and select the following options, and then select **Next**:
+8. On the **Configuration settings** page, enter and select the following options, and then select **Next**:
 
     - Network name: **Contoso Wi-Fi**
     - SSID: **MainOffice**
@@ -87,13 +87,13 @@ You have been asked to create a Configuration policy to be used to automatically
     - Security type: **WPA/WPA2-Personal**
     - Pre-Shared key: **ContosoWiFi123**
 
-9. On the **Assignments** blade, under **Included groups**, select **Add groups**.
+9. On the **Assignments** page, under **Included groups**, select **Add groups**.
 
 10. In the **Select groups to include** window, select **iOS_iPadOS Devices**, and then select **Select**.
 
-11. Select **Next** until you reach the **Review + create** blade. Select **Create**.
+11. Select **Next** until you reach the **Review + create** page. Select **Create**.
 
-12. Refresh the **Devices | Configuration** blade, and verify that the **iOS/iPadOS Wi-Fi Policy** is listed.
+12. Refresh the **Devices | Configuration** page, and verify that the **iOS/iPadOS Wi-Fi Policy** is listed.
 
 13. Close **Microsoft Edge**.
 


### PR DESCRIPTION
## Summary

Updates Lab 0303 (Using a Configuration Profile to configure iOS and iPadOS Wi-Fi settings) to fix a grammar error in the lab description, correct a UI drift where the Create button moved from the details pane to the Policies tab, add a missing navigation step after group creation, and apply Microsoft Learn style guidelines throughout.

## Changes

- Fixed grammar in lab description: removed erroneous word ("to run configure" → "to configure") in both YAML frontmatter and summary
- Added missing step to select **All groups** after creating the iOS_iPadOS Devices group (renumbered subsequent step)
- Updated Task 2 step 3 to reflect current UI: Create button is now in the **Policies** tab, not the details pane
- Applied bold formatting to **Microsoft Edge** references for consistency
- Changed "click" to "select" per Microsoft Learn style guidelines
- Updated action text in steps 7 and 8 to "enter and select" for accuracy
- Corrected Results tense from future perfect ("you will have successfully created") to present perfect ("you have successfully created")
- Removed trailing whitespace throughout

## Files changed

- `Instructions/Labs/0303-Using a Configuration Profile to configure iOS and iPadOS Wifi settings.md` — grammar fix in description, added navigation step after group creation, updated UI location for Create button, applied bold formatting and style fixes throughout