### PR TITLE
style(lab04/ex01): apply Microsoft Learn style and update terminology

### DIFF
--- a/Instructions/Labs/0401-Deploying cloud apps using Intune.md
+++ b/Instructions/Labs/0401-Deploying cloud apps using Intune.md
@@ -25,7 +25,8 @@ The following lab(s) must be completed before this lab:
 
 - 0204-Enrolling devices into Intune
 
-  > Note: You will also need a mobile phone that can receive text messages used to secure Windows Hello sign in authentication to Entra ID.
+  > [!NOTE]
+  > You will also need a mobile phone that can receive text messages used to secure Windows Hello sign-in authentication to Microsoft Entra ID.
 
 ## Exercise 1: Add a Microsoft Store App to Intune
 
@@ -39,19 +40,19 @@ You use Microsoft Intune to manage desktops and apps for Contoso Corporation. Th
 
 2. On the taskbar, select **Microsoft Edge**.
 
-3. In Microsoft Edge, type **https://intune.microsoft.com** in the address bar, and then press **Enter**.
+3. In **Microsoft Edge**, type **https://intune.microsoft.com** in the address bar, and then press **Enter**.
 
 4. Sign in as **`admin@yourtenant.onmicrosoft.com`** with the tenant Admin password.
 
-5. On the **Microsoft Intune admin center** page, select **Apps**.
+5. In the Microsoft Intune admin center, select **Apps**.
 
 6. On the **Apps** page, in the navigation pane, select **All apps**.
 
-7. In the details pane, select **+ Create**.
+7. In the **Apps | All apps** page, select **+ Create**.
 
-8. On the **Select app type** page, click the drop-down menu and then Choose **Microsoft store app (new)**. Click **Select**.
+8. On the **Select app type** pane, in the **Platform** drop-down menu, select **Windows**. For **App type**, select **Microsoft Store app (new)** and then select **Select**.
 
-9. On the **Add App** page, click **Seach the  Microsoft Store app (new)**, search for and select **Windows App**. Click **Select**.
+9. On the **Add App** page, select **Search the Microsoft Store app (new)**, search for and select **Windows App**. Select **Select**.
 
 10. On the **App information** page, verify the following information and then select **Next**:
     - Name: **Windows App**
@@ -61,7 +62,7 @@ You use Microsoft Intune to manage desktops and apps for Contoso Corporation. Th
 
 11. Select **Next** twice and then select **Create**.
 
-12. The Windows App page opens.
+12. The **Windows App** page opens.
 
     > Take note of the Properties, Device install status, and User install status nodes.
 


### PR DESCRIPTION
## Summary

Applies Microsoft Learn Markdown and style-guide conventions to Lab 04 Exercise 1 (Add a Microsoft Store App to Intune), and corrects minor terminology and typos.

## Changes

- Converted plain `> Note:` callout to `> [!NOTE]` syntax per Microsoft Learn Markdown reference
- Replaced deprecated term **Entra ID** with **Microsoft Entra ID**
- Replaced all instances of **click** with **select** per style guide
- Added bold emphasis to UI element names (Microsoft Edge, Windows App)
- Fixed typo: *Seach* → *Search*
- Clarified step descriptions (specified Platform drop-down and App type selection, corrected pane/page references)
- Hyphenated *sign in* → *sign-in* when used as a compound adjective

## Files changed

- `Instructions/Labs/0401-Deploying cloud apps using Intune.md` — style, terminology, and typo fixes in Exercise 1 Task 1 steps 3–12