### PR TITLE
fix(lab0402): update app protection policy lab for current Intune UI and style

### DIFF
--- a/Instructions/Labs/0402-Configure App Protection Policies for Mobile Devices.md
+++ b/Instructions/Labs/0402-Configure App Protection Policies for Mobile Devices.md
@@ -15,7 +15,7 @@ In this lab, you will configure an App protection policy for a mobile device.
 
 ### Scenario
 
-All of the developers at Contoso have iPhones and iPads running the latest iOS/iPadOS versions. The security department in is concerned with data leaks and wants to prevent data from the corporate e-mail to be copied out to other apps on the mobile devices. You must provide a solution that addresses the concerns from the security department. You need to ensure the following:
+All of the developers at Contoso have iPhones and iPads running the latest iOS/iPadOS versions. The security department is concerned with data leaks and wants to prevent data from corporate email from being copied to other apps on the mobile devices. You must provide a solution that addresses the concerns from the security department. You need to ensure the following:
 
 - Outlook data must be restricted from backing up to iTunes or iCloud.
 - Only policy managed apps can send and receive data from Outlook.
@@ -25,27 +25,27 @@ All of the developers at Contoso have iPhones and iPads running the latest iOS/i
 ### Task 1: Create an App protection policy for iOS/iPadOS devices
 
 1. On **SEA-SVR1**, if necessary, sign in as **Contoso\\Administrator** with the password **Pa55w.rd** and close **Server Manager**.
-    
+
 2. On the taskbar, select **Microsoft Edge**.
 
-3. In Microsoft Edge, type **https://intune.microsoft.com** in the address bar, and then press **Enter**. 
+3. In Microsoft Edge, type `https://intune.microsoft.com` in the address bar, and then press **Enter**.
 
 4. Sign in as **`admin@yourtenant.onmicrosoft.com`** with the tenant Admin password.
 
 5. On the **Microsoft Intune admin center** page, select **Apps**.
 
-6. On the **Apps | Overview** blade, under **Manage apps**, select **Protection**. 
+6. On the **Apps | Overview** blade, under **Manage apps**, select **Protection**.
 
-7. In the details pane, select **Create policy** and then select **iOS/iPadOS**.
+7. In the **Apps | Protection** blade, select **Create** and then select **iOS/iPadOS**.
 
 8. On the **Basics** tab, configure the following options and select **Next**:
 
-- Name: **Outlook – Developers**
-- Description: **Policy to prevent cut/copy and paste from Outlook**
+   - Name: **Outlook – Developers**
+   - Description: **Policy to prevent cut/copy and paste from Outlook**
 
-9. On the **Apps** tab, click **+ Select public apps**.
+9. On the **Apps** tab, select **+ Select public apps**.
 
-10. On the **Select apps to target** blade, in the text box, type **Outlook**. Select **Microsoft Outlook** and then select **Select**, and then select **Next**.
+10. On the **Select apps to target** pane, in the text box, type `Outlook`. From the results, select **Microsoft Outlook**, then select **Select**, and finally select **Next**.
 
 11. On the **Data protection** tab, configure the following options and select **Next**:
 
@@ -62,16 +62,22 @@ All of the developers at Contoso have iPhones and iPads running the latest iOS/i
 
 13. On the **Conditional launch** tab, review the settings. Select **Next**.
 
-    _Note: Here you can set the sign-in security requirements for your access protection policy. You can select a setting and enter the value that users must meet to sign in to your company app. Make note of the various settings but do not change anything._
+    > [!NOTE]
+    > Here you can set the sign-in security requirements for your access
+    > protection policy. You can select a setting and enter the value that
+    > users must meet to sign in to your company app. Make note of the
+    > various settings but do not change anything.
 
-14. On the **Assignments** tab, select **Next**. 
+14. On the **Assignments** tab, select **Next**.
 
-15. On the **Review + create** tab, review the settings and select **Create**. 
+15. On the **Review + create** tab, review the settings and select **Create**.
 
-17. On the **Apps | App protection policies** blade, in the details pane, verify that **Outlook - Developers** is listed.
+16. Select **Apps**.
+
+17. On the **Apps | Protection** blade, in the details pane, verify that **Outlook - Developers** is listed.
 
 18. Close Microsoft Edge.
 
-**Results**: After completing this exercise, you will have successfully configured an App protection policy for a mobile device.
+**Results**: After completing this exercise, you have successfully configured an App protection policy for a mobile device.
 
 **END OF LAB**

--- a/Instructions/Labs/0402-Configure App Protection Policies for Mobile Devices.md
+++ b/Instructions/Labs/0402-Configure App Protection Policies for Mobile Devices.md
@@ -34,9 +34,9 @@ All of the developers at Contoso have iPhones and iPads running the latest iOS/i
 
 5. On the **Microsoft Intune admin center** page, select **Apps**.
 
-6. On the **Apps | Overview** blade, under **Manage apps**, select **Protection**.
+6. On the **Apps | Overview** page, under **Manage apps**, select **Protection**.
 
-7. In the **Apps | Protection** blade, select **Create** and then select **iOS/iPadOS**.
+7. In the **Apps | Protection** page, select **Create** and then select **iOS/iPadOS**.
 
 8. On the **Basics** tab, configure the following options and select **Next**:
 
@@ -71,7 +71,7 @@ All of the developers at Contoso have iPhones and iPads running the latest iOS/i
 
 16. Select **Apps** , and then under **Manage apps**, select **Protection**.
 
-17. On the **Apps | Protection** blade, in the details pane, verify that **Outlook - Developers** is listed.
+17. On the **Apps | Protection** page, verify that **Outlook - Developers** is listed.
 
 18. Close Microsoft Edge.
 

--- a/Instructions/Labs/0402-Configure App Protection Policies for Mobile Devices.md
+++ b/Instructions/Labs/0402-Configure App Protection Policies for Mobile Devices.md
@@ -62,17 +62,14 @@ All of the developers at Contoso have iPhones and iPads running the latest iOS/i
 
 13. On the **Conditional launch** tab, review the settings. Select **Next**.
 
-    > [!NOTE]
-    > Here you can set the sign-in security requirements for your access
-    > protection policy. You can select a setting and enter the value that
-    > users must meet to sign in to your company app. Make note of the
-    > various settings but do not change anything.
+  > [!NOTE]
+  > Here you can set the sign-in security requirements for your access protection policy. You can select a setting and enter the value that users must meet to sign in to your company app. Make note of the various settings but do not change anything.
 
 14. On the **Assignments** tab, select **Next**.
 
 15. On the **Review + create** tab, review the settings and select **Create**.
 
-16. Select **Apps**.
+16. Select **Apps** , and then under **Manage apps**, select **Protection**.
 
 17. On the **Apps | Protection** blade, in the details pane, verify that **Outlook - Developers** is listed.
 


### PR DESCRIPTION
## Summary

Updates Practice Lab 0402 (Configure App Protection Policies for Mobile Devices) to match the current Microsoft Intune admin center UI and to comply with Microsoft Learn style guidelines.

## Changes

- Fixed grammar in the Scenario paragraph (`department in is` → `department is`; modernized `e-mail to be copied out` → `email from being copied to`).
- Updated step 7 to reflect the current UI: navigate via the **Apps | Protection** blade and select **Create** (instead of `details pane` / `Create policy`).
- Updated step 10 to reference the **Select apps to target** pane (formerly `blade`) and clarified the selection flow (`From the results, select Microsoft Outlook, then select Select, and finally select Next`).
- Replaced bold formatting on typed values with backticks (URL in step 3, `Outlook` text in step 10).
- Replaced `click` with `select` in step 9.
- Converted the legacy `_Note:_` italic note in step 13 to a proper `> [!NOTE]` callout block, indented to maintain numbered-list continuation.
- Added new step 16 (`Select Apps`) and updated step 17 to reference the **Apps | Protection** blade so the verification step matches the current navigation.
- Fixed list indentation under step 8 sub-items.
- Removed trailing whitespace and future tense in the Results line (`you will have successfully` → `you have successfully`).

## Files changed

- `Instructions/Labs/0402-Configure App Protection Policies for Mobile Devices.md` — grammar, UI label and navigation updates, style compliance (select vs click, backticks on typed values, NOTE callout), step renumbering for verification flow.
