### PR TITLE
fix(lab0503): exclude admin from CA policy and apply learn style

### DIFF
--- a/Instructions/Labs/0503-Configuring and validating device compliance.md
+++ b/Instructions/Labs/0503-Configuring and validating device compliance.md
@@ -53,7 +53,7 @@ If a device meets these requirements, it will be marked as compliant. If the dev
 
 5. From the navigation pane select **Devices**, then under **Manage devices**, select **Compliance**.
 
-6. On the **Devices | Compliance** blade, in the details pane select **+ Create policy**.
+6. On the **Devices | Compliance** page, select **+ Create policy**.
 
 7. On the **Create a policy** blade, provide the following value and select **Create**:
 

--- a/Instructions/Labs/0503-Configuring and validating device compliance.md
+++ b/Instructions/Labs/0503-Configuring and validating device compliance.md
@@ -27,13 +27,14 @@ The following lab(s) must be completed before this lab:
 
 - 0301-Creating and Deploying Configuration Profiles
 
-  > Note: You will also need a mobile phone that can receive text messages used to secure Windows Hello sign in authentication to Entra ID.
+  > [!NOTE]
+  > You will also need a mobile phone that can receive text messages used to secure Windows Hello sign in authentication to Entra ID.
 
 ## Exercise 1: Configuring compliance policies 
 
 ### Scenario
 
-Contoso would like to ensure that Windows devices that are enrolled in Intune meet a minimum configuration specification. The following are specifications are required:
+Contoso would like to ensure that Windows devices that are enrolled in Intune meet a minimum configuration specification. The following specifications are required:
 
 - Minimum Windows operating system version: 10.0.19041.329
 - Microsoft Defender Antimalware required
@@ -46,11 +47,11 @@ If a device meets these requirements, it will be marked as compliant. If the dev
 
 2. On the taskbar, select **Microsoft Edge**.
 
-3. In Microsoft Edge, type **https://intune.microsoft.com** in the  address bar, and then press **Enter**. 
+3. In Microsoft Edge, type **https://intune.microsoft.com** in the address bar, and then press **Enter**. 
 
-4. Sign in as as **`admin@yourtenant.onmicrosoft.com`** with the default tenant password.
+4. Sign in as **`admin@yourtenant.onmicrosoft.com`** with the default tenant password.
 
-5. From the navigation pane select **Devices**, then select **Compliance**.
+5. From the navigation pane select **Devices**, then under **Manage devices**, select **Compliance**.
 
 6. On the **Devices | Compliance** blade, in the details pane select **+ Create policy**.
 
@@ -65,18 +66,18 @@ If a device meets these requirements, it will be marked as compliant. If the dev
 
 9. On the **Compliance settings** tab, expand **Device Health** and review the available settings.
 
-10. On the **Compliance settings** tab, expand **Device Properties**. In the **Minimum OS version**
-    field, type **10.0.19041.329**.
+10. On the **Compliance settings** tab, expand **Device Properties**. In the **Minimum OS version** field, type **10.0.19041.329**.
 
 11. On the **Compliance settings** tab, expand **System Security**. Set the **Microsoft Defender Antimalware** setting to **Require**. 
 
 12. Select **Next**. On the **Actions for noncompliance** tab, note the action to **Mark device noncompliant** default setting is **immediately**. 
 
-    > Review how you can configure the number of days after which the device is marked as noncompliant, and configuration additional actions. 
+    > Review how you can configure the number of days after which the device is marked as noncompliant, and configure additional actions. 
 
-13. Select **Next**. On the **Assignments** tab, under **Included groups** select **Add groups**. Select **Windows Devices**, choose **Select**, and then select **Next**. 
+13. Select **Next**. On the **Assignments** tab, under **Included groups** select **Add groups**. Choose **Windows Devices**, select **Select** followed by **Next**. 
 
-    _Note: The **Windows Devices** group was created in Lab 0301: Creating and Deploying Configuration Profiles._
+  > [!NOTE]
+  > The **Windows Devices** group was created in Lab 0301: Creating and Deploying Configuration Profiles.
 
 14. On the **Review + create** tab, review the settings and then select **Create**.
 
@@ -92,7 +93,6 @@ If a device meets these requirements, it will be marked as compliant. If the dev
 
 **Results**: After completing this exercise, you will have successfully configured a compliance policy.
 
-
 ## Exercise 2: Creating a conditional access policy to enforce compliance
 
 ### Scenario 
@@ -107,25 +107,32 @@ When a user uses a device that is marked as non-compliant, they should not be ab
 
 3. On the **Conditional Access | Policies** blade, select **+ New policy**.
 
-4. On the **New** blade, in the **Name** text box, type **Conditional1** and then select **0 users or agents (Preview) selected**.
+4. On the **New** blade, in the **Name** text box, type `Conditional1` and then select **0 users or agents selected**.
 
 5. Under **Include**, select the **All users** radio button.
 
-6. In the **Target resources** section, select **No target resources selected**.
+6. Select the **Exclude** tab, and then select the **Users and groups** check box.
 
-7. Under **Include** choose the **Select resources** radio button, under the **Select specific resources** heading, select **None**
+7. In the **Exclude** pane, select your administrator account (**`admin@yourtenant.onmicrosoft.com`**), and then select **Select**.
 
-8. In the **Resources** page, enter **Office 365** in the search box, and then select the checkbox next for **Office 365 Exchange Online**, and then click **Select**.
+   > [!IMPORTANT]
+   > Excluding your administrator account prevents you from being locked out by this policy. Without an exclusion, an admin signing in from a noncompliant device can be blocked from the targeted resources and may face repeated sign-in prompts until the policy is disabled.
 
-9. In the **Conditions** section, select **0 conditions selected**. 
+8. In the **Target resources** section, select **No target resources selected**.
 
-10. In the list of conditions, under **Device platforms**, select **Not configured**. In the **Configure** section select **Yes**, choose the **Select device platforms** radio button, select the **Windows** check box, and then select **Done**.
+9. Under **Include** choose the **Select resources** radio button, under the **Select specific resources** heading, select **None**.
 
-11. In the **Grant** section, select **0 controls selected**. Select the **Require device to be marked as compliant** check box, and then click **Select**.
+10. In the **Resources** page, enter **Office 365** in the search box, and then select the checkbox next for **Office 365 Exchange Online**, and then select **Select**.
 
-12. On the **New** blade, select **On** for the **Enable policy** option and then select **Create**.
+11. In the **Conditions** section, select **0 conditions selected**. 
 
-13. Close Microsoft Edge.
+12. In the list of conditions, under **Device platforms**, select **Not configured**. In the **Configure** section select **Yes**, choose the **Select device platforms** radio button, select the **Windows** check box, and then select **Done**.
+
+13. In the **Grant** section, select **0 controls selected**. Select the **Require device to be marked as compliant** check box, and then select **Select**.
+
+14. On the **New** blade, select **On** for the **Enable policy** option and then select **Create**.
+
+15. Close Microsoft Edge.
 
 ### Task 2: Verify that the conditional access policy is working
 
@@ -135,11 +142,12 @@ When a user uses a device that is marked as non-compliant, they should not be ab
 
 3. In Microsoft Edge, type **outlook.office.com** and then press Enter.
 
-4. On the pick an account dialog box, select **`Aaron@yourtenant.onmicrosoft.com`**.
+4. On the **Pick an account** dialog box, select **`Aaron@yourtenant.onmicrosoft.com`**.
 
 5. On the **Enter password** page, enter **Pa55w.rd1234!** and select **Sign in**.
 
-    > **Note** If the Microsoft Edge Save password prompt appears, select **Update**.
+   > [!NOTE]
+   > If the Microsoft Edge Save password prompt appears, select **Update**.
 
 6. You should receive a message that asks you to switch Edge profile. Select **Switch Edge profile**.
 
@@ -147,15 +155,17 @@ When a user uses a device that is marked as non-compliant, they should not be ab
 
 8. You will be required to enter your password again. Enter **Pa55w.rd1234!** and select **Sign in**.
 
-9. A dialog box will appear asking, "**Automatically sign in to all desktops apps and websites on this device?**". Select **No, sign in to this app only**.
+9. A dialog box will appear asking, "**Sign in to all apps and websites on this device?**". Select **No, this app only**.
 
-    > Note: A page will appear stating, "**Let's set up your profile to access org resources**". This is because SEA-WS3 is not joined to Entra ID and not managed by Intune. As such, you are unable to access Aarons' mailbox from this device.
+   > [!NOTE]
+   > A page will appear stating, "**Let's set up your profile to access org resources**". This is because SEA-WS3 is not joined to Entra ID and not managed by Intune. As such, you are unable to access Aaron's mailbox from this device.
 
-10. **Close** all windows and sign out of **SEA-WS3**.
+10. Close all windows and sign out of **SEA-WS3**.
 
-11. Switch to **SEA-WS1**, and sign in as as Aaron Nicholls with the PIN **102938**. 
+11. Switch to **SEA-WS1**, and sign in as Aaron Nicholls with the PIN **102938**. 
 
-    > Note: SEA-WS1 is a managed Windows 11 device that is enrolled in Intune.
+   > [!NOTE]
+   > SEA-WS1 is a managed Windows 11 device that is enrolled in Intune.
 
 12. On the taskbar, select **Microsoft Edge**.
 
@@ -163,7 +173,8 @@ When a user uses a device that is marked as non-compliant, they should not be ab
 
 14. Verify that you can access Aaron's mailbox. 
 
-    > Note: This is because SEA-WS1 is a managed device and marked as compliant.
+   > [!NOTE]
+   > This is because SEA-WS1 is a managed device and marked as compliant.
 
 15. Close Microsoft Edge and sign out of SEA-WS1.
 
@@ -175,7 +186,7 @@ When a user uses a device that is marked as non-compliant, they should not be ab
 
 3. In Microsoft Edge, type **https://intune.microsoft.com** in the address bar, and then press **Enter**.
 
-4. Sign in as as **`admin@yourtenant.onmicrosoft.com`** with the default tenant password.
+4. Sign in as **`admin@yourtenant.onmicrosoft.com`** with the default tenant password.
 
 5. From the navigation pane select **Devices**, then select **All devices**.
 
@@ -183,12 +194,14 @@ When a user uses a device that is marked as non-compliant, they should not be ab
 
 6. From the navigation pane select **Devices**, then select **Conditional access**.
 
-7. On the **Conditional Access** page, select **Policies** and then select **Conditional1**.
+7. On the **Conditional Access** page, select **Policies**, and then select **Conditional1**.
 
-8. On the **Conditional1** page, at the bottom of the page, select **Off** and then select **Save**.
+8. On the **Conditional1** page, select **View or Edit**.
 
-9. Close Microsoft Edge.
+9. At the bottom of the page, under **Enable policy**, select **Off**, and then select **Save**.
 
-**Results**: After completing this exercise, you will have successfully configured a conditional access policy to determine device compliance.
+10. Close Microsoft Edge.
+
+**Results**: After completing this exercise, you have successfully configured a conditional access policy to determine device compliance.
 
 **END OF LAB**


### PR DESCRIPTION
## Summary

This PR hardens the conditional access exercise in Lab 0503 by excluding the administrator account from the compliance-enforcing CA policy to prevent admin lockout, and brings the entire lab into line with Microsoft Learn style guidelines.

## Changes

- **Exercise 2, Task 1:** Added steps to exclude the administrator account from the conditional access policy, with an `[!IMPORTANT]` callout explaining how this prevents lockout and repeated sign-in prompts from a noncompliant device. Renumbered the remaining steps accordingly.
- **Exercise 2, Task 3:** Added the **View or Edit** step and clarified how to disable the policy under **Enable policy**.
- **Style:** Converted legacy `> Note:` and `_Note:_` blocks to `> [!NOTE]` / `[!IMPORTANT]` callout blocks, replaced "click" with "select", and corrected bold/backtick usage on typed values (e.g., `Conditional1`).
- **Grammar:** Removed duplicated "as as", fixed "The following are specifications are required", "configuration additional actions" -> "configure additional actions", "Aarons'" -> "Aaron's", and "you will have successfully" -> "you have successfully".

## Files changed

- `Instructions/Labs/0503-Configuring and validating device compliance.md` — added admin exclusion steps with IMPORTANT callout, added View or Edit step, converted notes to callout blocks, replaced click with select, and applied grammar and formatting fixes.
